### PR TITLE
Fix shadcdn persistence after server restart

### DIFF
--- a/my-story-port-main/index.html
+++ b/my-story-port-main/index.html
@@ -10,8 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <!-- SwiperJS CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
+    <!-- Swiper styles are imported via modules in components -->
 
     
 
@@ -25,9 +24,9 @@
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
   </head>
 
-  <body class="bg-gradient-to-r from-gray-800 via-blue-700 to-gray-900">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
+    <!-- Swiper script removed; using npm package -->
   </body>
 </html>

--- a/my-story-port-main/package-lock.json
+++ b/my-story-port-main/package-lock.json
@@ -54,6 +54,7 @@
         "react-router-dom": "^6.30.1",
         "recharts": "^2.15.4",
         "sonner": "^1.7.4",
+        "swiper": "^11.2.10",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.9",
@@ -6284,6 +6285,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
+      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/my-story-port-main/package.json
+++ b/my-story-port-main/package.json
@@ -57,6 +57,7 @@
     "react-router-dom": "^6.30.1",
     "recharts": "^2.15.4",
     "sonner": "^1.7.4",
+    "swiper": "^11.2.10",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",

--- a/my-story-port-main/src/components/portfolio/portfolio-section.tsx
+++ b/my-story-port-main/src/components/portfolio/portfolio-section.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useRef } from "react";
+import Swiper from "swiper";
+import { Autoplay, FreeMode } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/free-mode";
 import { PortfolioCard } from "@/components/ui/portfolio-card";
 
 const portfolioProjects = [
@@ -69,12 +73,10 @@ export const PortfolioSection = () => {
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const SwiperGlobal = (window as any).Swiper;
-    if (!SwiperGlobal) return;
-
     const makeSwiper = (el: HTMLDivElement, reverse = false) =>
-      new SwiperGlobal(el, {
-        slidesPerView: 'auto',
+      new Swiper(el, {
+        modules: [Autoplay, FreeMode],
+        slidesPerView: "auto",
         spaceBetween: 16,
         loop: true,
         loopAdditionalSlides: 6,

--- a/my-story-port-main/src/components/portfolio/services-section.tsx
+++ b/my-story-port-main/src/components/portfolio/services-section.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useRef } from "react";
+import Swiper from "swiper";
+import { Autoplay, FreeMode } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/free-mode";
 import { ServiceCard } from "@/components/ui/service-card";
 import { PenTool, MessageSquare, Target, BarChart3 } from "lucide-react";
 
@@ -33,9 +37,10 @@ export const ServicesSection = () => {
   const swiperRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!swiperRef.current || !(window as any).Swiper) return;
-    const swiper = new (window as any).Swiper(swiperRef.current, {
-      slidesPerView: 'auto',
+    if (!swiperRef.current) return;
+    const swiper = new Swiper(swiperRef.current, {
+      modules: [Autoplay, FreeMode],
+      slidesPerView: "auto",
       spaceBetween: 16,
       loop: true,
       loopAdditionalSlides: 6,


### PR DESCRIPTION
Localize Swiper.js and remove hard-coded `body` styles to ensure changes persist across server restarts.

The user reported that changes were not persisting after server restarts. This was due to Swiper.js being loaded via a CDN, which could override local component logic, and a hard-coded Tailwind gradient in `index.html` that prevented local CSS from taking effect. By vendoring Swiper.js and removing the inline gradient, all relevant styles and scripts are now managed locally.

---
<a href="https://cursor.com/background-agent?bcId=bc-78847d0f-2a71-407d-a9e9-a988d87b8334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78847d0f-2a71-407d-a9e9-a988d87b8334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

